### PR TITLE
better compilation chain + readme draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+libgokcore.*

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 CC = gcc
 CFLAGS = -fPIC -I/home/kblondel/Downloads/android-studio/jre/include/linux -I/home/kblondel/Downloads/android-studio/jre/include/ -I./headers
 LDFLAGS = -L./
-LIBS = -lgokcore
+LIBS = -lgokcore -ljson-c
 SRCS = kcore_wrap.c
 OBJS = $(SRCS:.c=.o)
 TARGET = libkcore.so
 
-GOCC = /usr/local/bin/go
+GOROOT ?= /usr/local
+GOCC = $(GOROOT)/bin/go
 GOFLAGS = -buildmode=c-shared
 GOSRC = ./cgo/kuzzle/
 GOTARGET = libgokcore.so
@@ -19,6 +20,9 @@ kcore_wrap.o: kcore_wrap.c
 	$(CC) -ggdb -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(LIBS)
 
 core:
+ifeq ($(wildcard $(GOCC)),)
+	$(error "Unable to find go compiler")
+endif
 	$(GOCC) build -o $(GOTARGET) $(GOFLAGS) $(GOSRC)
 
 wrapper: $(OBJS)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# SDK Wrappers
+
+This project contains a CGO wrapper to Kuzzle's [Go SDK](https://github.com/kuzzleio/sdk-go) and [SWIG templates](http://www.swig.org/), allowing to publish Kuzzle's SDK in multiple languages.
+
+# Pre-requisites
+
+* [Go](https://golang.org/doc/install)
+* [JSON-C library](https://github.com/json-c/json-c#install-using-apt-eg-ubuntu-16042-lts)
+
+# Contributing
+
+* Clone this project:
+
+```sh
+$ git clone git@github.com:kuzzleio/sdk-wrappers.git
+```
+
+* Build all SDKs:
+
+```sh
+$ make
+```
+
+* If you need to build the CGO wrapper only:
+
+```sh
+$ make core
+```

--- a/headers/kuzzle.h
+++ b/headers/kuzzle.h
@@ -1,7 +1,7 @@
 #ifndef _KUZZLE_H_
 #define _KUZZLE_H_
 
-#include <json/json.h>
+#include <json-c/json.h>
 #include <time.h>
 #include <errno.h>
 


### PR DESCRIPTION
* makefile now looks for the go compiler in $GOROOT/bin, it then fallbacks to /usr/local/bin, and cleanly exits if it cannot find it in either locations
* json-c installs its headers in `json-c/json.h` instead of `json/json.h`
* add a first draft of a README file to make it easier for new contributors to now how to start with the project
* makes git ignore built files