### PR TITLE
Args by ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 CC = gcc
 CFLAGS = -fPIC -I/home/kblondel/Downloads/android-studio/jre/include/linux -I/home/kblondel/Downloads/android-studio/jre/include/ -I./headers
 LDFLAGS = -L./
-LIBS = -lgokcore
+LIBS = -lgokcore -ljson-c
 SRCS = kcore_wrap.c
 OBJS = $(SRCS:.c=.o)
 TARGET = libkcore.so
 
-GOCC = /usr/local/bin/go
+GOROOT ?= /usr/local
+GOCC = $(GOROOT)/bin/go
 GOFLAGS = -buildmode=c-shared
 GOSRC = ./cgo/kuzzle/
 GOTARGET = libgokcore.so
@@ -19,6 +20,9 @@ kcore_wrap.o: kcore_wrap.c
 	$(CC) -ggdb -c $< -o $@ $(CFLAGS) $(LDFLAGS) $(LIBS)
 
 core:
+ifeq ($(wildcard $(GOCC)),)
+	$(error "Unable to find go compiler")
+endif
 	$(GOCC) build -o $(GOTARGET) $(GOFLAGS) $(GOSRC)
 
 wrapper: $(OBJS)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# SDK Wrappers
+
+This project contains a CGO wrapper to Kuzzle's [Go SDK](https://github.com/kuzzleio/sdk-go) and [SWIG templates](http://www.swig.org/), allowing to publish Kuzzle's SDK in multiple languages.
+
+# Pre-requisites
+
+* [Go](https://golang.org/doc/install)
+* [JSON-C library](https://github.com/json-c/json-c#install-using-apt-eg-ubuntu-16042-lts)
+
+# Contributing
+
+* Clone this project:
+
+```sh
+$ git clone git@github.com:kuzzleio/sdk-wrappers.git
+```
+
+* Build all SDKs:
+
+```sh
+$ make
+```
+
+* If you need to build the CGO wrapper only:
+
+```sh
+$ make core
+```

--- a/cgo/kuzzle/add_listener.go
+++ b/cgo/kuzzle/add_listener.go
@@ -19,7 +19,7 @@ import (
 func kuzzle_wrapper_add_listener(k *C.Kuzzle, e C.int, cb unsafe.Pointer) {
 	c := make(chan interface{})
 
-	kuzzle.AddListener(*(*kuzzle.Kuzzle)(k.instance), int(e), c)
+	kuzzle.AddListener((*kuzzle.Kuzzle)(k.instance), int(e), c)
 	go func() {
 		res := <-c
 

--- a/cgo/kuzzle/json_cgo.go
+++ b/cgo/kuzzle/json_cgo.go
@@ -133,7 +133,7 @@ func (parser *JsonParser) parseArray(jobj *C.json_object, key *C.char, content m
 	var jvalue *C.json_object
 
 	for i := 0; i < int(arraylen); i++ {
-		jvalue = C.json_object_array_get_idx(jarray, C.int(i))
+		jvalue = C.json_object_array_get_idx(jarray, C.size_t(i))
 		jtype := C.json_object_get_type(jvalue)
 		if jtype == C.json_type_array {
 			parser.parseArray(jvalue, nil, content)

--- a/cgo/kuzzle/kuzzle.go
+++ b/cgo/kuzzle/kuzzle.go
@@ -45,8 +45,7 @@ func kuzzle_wrapper_connect(k *C.Kuzzle) *C.char {
 //export kuzzle_wrapper_get_offline_queue
 func kuzzle_wrapper_get_offline_queue(k *C.Kuzzle, result *C.offline_queue) {
 	offlineQueue := (*kuzzle.Kuzzle)(k.instance).GetOfflineQueue()
-	qooo := types.QueryObject{RequestId: "test"}
-	*offlineQueue = append(*offlineQueue, qooo)
+	*offlineQueue = append(*offlineQueue, &types.QueryObject{RequestId: "test"})
 
 	cArray := C.malloc(C.size_t(len(*offlineQueue)) * C.size_t(unsafe.Sizeof(uintptr(0))))
 

--- a/cgo/kuzzle/query.go
+++ b/cgo/kuzzle/query.go
@@ -77,17 +77,17 @@ func kuzzle_wrapper_query(k *C.Kuzzle, result *C.kuzzle_response, request *C.kuz
 	req.Volatile = jp.GetContent()
 
 	start := int(request.start)
-	req.Start = &start
+	req.Start = start
 
 	cursor := int(request.cursor)
-	req.Cursor = &cursor
+	req.Cursor = cursor
 
 	req.Members = goStrings(request.members)
 	req.Keys = goStrings(request.keys)
 	req.Fields = goStrings(request.fields)
 
-	resC := make(chan types.KuzzleResponse)
-	(*kuzzle.Kuzzle)(k.instance).Query(req, opts, resC)
+	resC := make(chan *types.KuzzleResponse)
+	(*kuzzle.Kuzzle)(k.instance).Query(&req, opts, resC)
 
 	res := <-resC
 

--- a/headers/kuzzle.h
+++ b/headers/kuzzle.h
@@ -1,7 +1,7 @@
 #ifndef _KUZZLE_H_
 #define _KUZZLE_H_
 
-#include <json/json.h>
+#include <json-c/json.h>
 #include <time.h>
 #include <errno.h>
 


### PR DESCRIPTION
Makes the CGO wrapper compatible with the new Go SDK version, using references instead of objects themselves.

:warning: only compatible with the Go SDK after https://github.com/kuzzleio/sdk-go/pull/81 is merged :warning: 

Other dependency: https://github.com/kuzzleio/sdk-wrappers/pull/20