### PR TITLE
Dynamic arrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -fPIC -I/home/kblondel/Downloads/android-studio/jre/include/linux -I/home/kblondel/Downloads/android-studio/jre/include/ -I./headers
+CFLAGS = -fPIC -I$(PWD)/headers
 LDFLAGS = -L./
 LIBS = -lgokcore -ljson-c
 SRCS = kcore_wrap.c

--- a/cgo/kuzzle/add_listener.go
+++ b/cgo/kuzzle/add_listener.go
@@ -2,7 +2,9 @@ package main
 
 /*
 	#cgo CFLAGS: -I../../headers
-	#include <kuzzle.h>
+
+	#include <stdlib.h>
+	#include "kuzzle.h"
 
 	static void call(void* f, json_object* res) {
 		((void(*)(json_object*))f)(res);

--- a/cgo/kuzzle/add_listener.go
+++ b/cgo/kuzzle/add_listener.go
@@ -26,7 +26,10 @@ func kuzzle_wrapper_add_listener(k *C.Kuzzle, e C.int, cb unsafe.Pointer) {
 		var jsonRes *C.json_object
 		r, _ := json.Marshal(res)
 
-		jsonRes = C.json_tokener_parse(C.CString(string(r)))
+		buffer := C.CString(string(r))
+		defer C.free(unsafe.Pointer(buffer))
+
+		jsonRes = C.json_tokener_parse(buffer)
 
 		C.call(cb, jsonRes)
 	}()

--- a/cgo/kuzzle/check_token.go
+++ b/cgo/kuzzle/check_token.go
@@ -14,13 +14,14 @@ import (
 func kuzzle_wrapper_check_token(k *C.Kuzzle, token *C.char) *C.token_validity {
 	result := (*C.token_validity)(C.calloc(1, C.sizeof_token_validity))
 
-	if result == nil:
+	if result == nil {
 		return result
+	}
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).CheckToken(C.GoString(token))
 
 	if err != nil {
-		result.error = C.CString(err.Error())
+		Set_token_validity_error(result, err)
 		return result
 	}
 
@@ -30,8 +31,9 @@ func kuzzle_wrapper_check_token(k *C.Kuzzle, token *C.char) *C.token_validity {
 		result.valid = 0
 	}
 
+	result.status = 200
 	result.state = C.CString(res.State)
-	result.expiresAt = C.int(res.ExpiresAt)
+	result.expiresAt = C.longlong(res.ExpiresAt)
 
 	return result
 }

--- a/cgo/kuzzle/check_token.go
+++ b/cgo/kuzzle/check_token.go
@@ -14,10 +14,6 @@ import (
 func kuzzle_wrapper_check_token(k *C.Kuzzle, token *C.char) *C.token_validity {
 	result := (*C.token_validity)(C.calloc(1, C.sizeof_token_validity))
 
-	if result == nil {
-		return result
-	}
-
 	res, err := (*kuzzle.Kuzzle)(k.instance).CheckToken(C.GoString(token))
 
 	if err != nil {

--- a/cgo/kuzzle/check_token.go
+++ b/cgo/kuzzle/check_token.go
@@ -3,7 +3,7 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#include <stdlib.h>
-	#include <kuzzle.h>
+	#include "kuzzle.h"
  */
 import "C"
 import (
@@ -16,8 +16,8 @@ func kuzzle_wrapper_check_token(k *C.Kuzzle, token *C.char) *C.token_validity {
 	result := (*C.token_validity)(C.calloc(1, C.sizeof_token_validity))
 
 	if err != nil {
-			result.error = C.CString(err.Error())
-			return result
+		result.error = C.CString(err.Error())
+		return result
 	}
 
 	if res.Valid {

--- a/cgo/kuzzle/check_token.go
+++ b/cgo/kuzzle/check_token.go
@@ -12,8 +12,12 @@ import (
 
 //export kuzzle_wrapper_check_token
 func kuzzle_wrapper_check_token(k *C.Kuzzle, token *C.char) *C.token_validity {
-	res, err := (*kuzzle.Kuzzle)(k.instance).CheckToken(C.GoString(token))
 	result := (*C.token_validity)(C.calloc(1, C.sizeof_token_validity))
+
+	if result == nil:
+		return result
+
+	res, err := (*kuzzle.Kuzzle)(k.instance).CheckToken(C.GoString(token))
 
 	if err != nil {
 		result.error = C.CString(err.Error())

--- a/cgo/kuzzle/create_index.go
+++ b/cgo/kuzzle/create_index.go
@@ -16,10 +16,6 @@ import (
 func kuzzle_wrapper_create_index(k *C.Kuzzle, index *C.char, options *C.query_options) *C.ack_response {
 	result := (*C.ack_response)(C.calloc(1, C.sizeof_ack_response))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/create_index.go
+++ b/cgo/kuzzle/create_index.go
@@ -8,7 +8,6 @@ package main
 import "C"
 import (
 	"github.com/kuzzleio/sdk-go/types"
-	"unsafe"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 )
 
@@ -24,28 +23,21 @@ func kuzzle_wrapper_create_index(k *C.Kuzzle, result *C.ack_response, index *C.c
 		if err.Error() == "Collection.createIndex: index required" {
 			return C.int(C.EINVAL)
 		} else {
-			result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+			result.error = C.CString(err.Error())
 			return 0
 		}
 	}
 
-	var ack, shardsAck C.uint
-
 	if res.Acknowledged {
-		ack = 1
+		result.acknowledged = 1
 	} else {
-		ack = 0
+		result.acknowledged = 0
 	}
 
 	if res.ShardsAcknowledged {
-		shardsAck = 1
+		result.shardsAcknowledged = 1
 	} else {
-		shardsAck = 0
-	}
-
-	*result = C.ack_response{
-		acknowledged:       ack,
-		shardsAcknowledged: shardsAck,
+		result.shardsAcknowledged = 0
 	}
 
 	return 0

--- a/cgo/kuzzle/create_my_credentials.go
+++ b/cgo/kuzzle/create_my_credentials.go
@@ -28,7 +28,7 @@ func kuzzle_wrapper_create_my_credentials(k *C.Kuzzle, result *C.json_result, st
 		if err.Error() == "Kuzzle.CreateMyCredentials: strategy is required" {
 			return C.int(C.EINVAL)
 		} else {
-			result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+			result.error = C.CString(err.Error())
 			return 0
 		}
 	}

--- a/cgo/kuzzle/create_my_credentials.go
+++ b/cgo/kuzzle/create_my_credentials.go
@@ -18,10 +18,6 @@ import (
 func kuzzle_wrapper_create_my_credentials(k *C.Kuzzle, strategy *C.char, credentials *C.json_object, options *C.query_options) *C.json_result {
 	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/delete_my_credentials.go
+++ b/cgo/kuzzle/delete_my_credentials.go
@@ -17,10 +17,6 @@ import (
 func kuzzle_wrapper_delete_my_credentials(k *C.Kuzzle, strategy *C.char, options *C.query_options) *C.ack_response {
 	result := (*C.ack_response)(C.calloc(1, C.sizeof_ack_response))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/disconnect.go
+++ b/cgo/kuzzle/disconnect.go
@@ -2,7 +2,7 @@ package main
 
 /*
 	#cgo CFLAGS: -I../../headers
-	#include <kuzzle.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (

--- a/cgo/kuzzle/flush_queue.go
+++ b/cgo/kuzzle/flush_queue.go
@@ -2,7 +2,7 @@ package main
 
 /*
 	#cgo CFLAGS: -I../../headers
-	#include <kuzzle.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (

--- a/cgo/kuzzle/get_all_statistics.go
+++ b/cgo/kuzzle/get_all_statistics.go
@@ -19,10 +19,6 @@ import (
 func kuzzle_wrapper_get_all_statistics(k *C.Kuzzle, options *C.query_options) *C.json_result {
 	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/get_auto_refresh.go
+++ b/cgo/kuzzle/get_auto_refresh.go
@@ -15,10 +15,6 @@ import (
 func kuzzle_wrapper_get_auto_refresh(k *C.Kuzzle, index *C.char, options *C.query_options) *C.bool_result {
 	result := (*C.bool_result)(C.calloc(1, C.sizeof_bool_result))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/get_headers.go
+++ b/cgo/kuzzle/get_headers.go
@@ -2,7 +2,8 @@ package main
 
 /*
 	#cgo CFLAGS: -I../../headers
-	#include <kuzzle.h>
+  #include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
@@ -15,5 +16,8 @@ func kuzzle_wrapper_get_headers(k *C.Kuzzle) *C.json_object {
 	res := (*kuzzle.Kuzzle)(k.instance).GetHeaders()
 	r, _ := json.Marshal(res)
 
-	return C.json_tokener_parse(C.CString(string(r)))
+  buffer := C.CString(string(r))
+  defer C.free(unsafe.Pointer(buffer))
+	
+  return C.json_tokener_parse(buffer)
 }

--- a/cgo/kuzzle/get_headers.go
+++ b/cgo/kuzzle/get_headers.go
@@ -7,6 +7,7 @@ package main
 */
 import "C"
 import (
+  "unsafe"
 	"encoding/json"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 )

--- a/cgo/kuzzle/get_my_credentials.go
+++ b/cgo/kuzzle/get_my_credentials.go
@@ -18,10 +18,6 @@ import (
 func kuzzle_wrapper_get_my_credentials(k *C.Kuzzle, strategy *C.char, options *C.query_options) *C.json_result {
 	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/get_my_rights.go
+++ b/cgo/kuzzle/get_my_rights.go
@@ -30,7 +30,7 @@ func kuzzle_wrapper_get_my_rights(k *C.Kuzzle, options *C.query_options) *C.json
 	}
 
 	r, _ := json.Marshal(res)
-  buffer := C.CString(string(r))
+	buffer := C.CString(string(r))
 	result.result = C.json_tokener_parse(buffer)
 
 	C.free(unsafe.Pointer(buffer))

--- a/cgo/kuzzle/get_my_rights.go
+++ b/cgo/kuzzle/get_my_rights.go
@@ -14,18 +14,28 @@ import (
 )
 
 //export kuzzle_wrapper_get_my_rights
-func kuzzle_wrapper_get_my_rights(k *C.Kuzzle, result *C.json_result, options *C.query_options) {
+func kuzzle_wrapper_get_my_rights(k *C.Kuzzle, options *C.query_options) *C.json_result {
+	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
+
+	if result == nil {
+		return result
+	}
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
 	}
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).GetMyRights(opts)
+
 	if err != nil {
-		result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
-		return
+		Set_json_result_error(result, err)
+		return result
 	}
 
 	r, _ := json.Marshal(res)
-	result.result = C.json_tokener_parse(C.CString(string(r)))
+  buffer := C.CString(string(r))
+  defer C.free(unsafe.Pointer(buffer))
+
+	result.result = C.json_tokener_parse(buffer)
 }

--- a/cgo/kuzzle/get_my_rights.go
+++ b/cgo/kuzzle/get_my_rights.go
@@ -33,6 +33,6 @@ func kuzzle_wrapper_get_my_rights(k *C.Kuzzle, options *C.query_options) *C.json
   buffer := C.CString(string(r))
 	result.result = C.json_tokener_parse(buffer)
 
-  C.free(unsafe.Pointer(buffer))
+	C.free(unsafe.Pointer(buffer))
 	return result
 }

--- a/cgo/kuzzle/get_my_rights.go
+++ b/cgo/kuzzle/get_my_rights.go
@@ -17,10 +17,6 @@ import (
 func kuzzle_wrapper_get_my_rights(k *C.Kuzzle, options *C.query_options) *C.json_result {
 	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -35,7 +31,8 @@ func kuzzle_wrapper_get_my_rights(k *C.Kuzzle, options *C.query_options) *C.json
 
 	r, _ := json.Marshal(res)
   buffer := C.CString(string(r))
-  defer C.free(unsafe.Pointer(buffer))
-
 	result.result = C.json_tokener_parse(buffer)
+
+  C.free(unsafe.Pointer(buffer))
+	return result
 }

--- a/cgo/kuzzle/get_server_info.go
+++ b/cgo/kuzzle/get_server_info.go
@@ -17,10 +17,6 @@ import (
 func kuzzle_wrapper_get_server_info(k *C.Kuzzle, options *C.query_options) *C.json_result {
 	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
 
-	if result == nil {
-		return result
-	}
-
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)

--- a/cgo/kuzzle/get_server_info.go
+++ b/cgo/kuzzle/get_server_info.go
@@ -14,18 +14,30 @@ import (
 )
 
 //export kuzzle_wrapper_get_server_info
-func kuzzle_wrapper_get_server_info(k *C.Kuzzle, result *C.json_result, options *C.query_options) {
+func kuzzle_wrapper_get_server_info(k *C.Kuzzle, options *C.query_options) *C.json_result {
+	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
+
+	if result == nil {
+		return result
+	}
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
 	}
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).GetServerInfo(opts)
+
 	if err != nil {
-		result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
-		return
+		Set_json_result_error(result, err)
+		return result
 	}
 
 	r, _ := json.Marshal(res)
-	result.result = C.json_tokener_parse(C.CString(string(r)))
+	buffer := C.CString(string(r))
+	defer C.free(unsafe.Pointer(buffer))
+
+	result.result = C.json_tokener_parse(buffer)
+
+	return result
 }

--- a/cgo/kuzzle/json_cgo.go
+++ b/cgo/kuzzle/json_cgo.go
@@ -15,69 +15,64 @@ func (parser *JsonParser) get_json_value(key string, jobj *C.json_object, conten
 	jtype := C.json_object_get_type(jobj)
 
 	switch jtype {
-	case C.json_type_boolean:
-		var v bool
-		if int(C.json_object_get_boolean(jobj)) == 1 {
-			v = true
-		} else {
-			v = false
-		}
+		case C.json_type_boolean:
+			v := int(C.json_object_get_boolean(jobj)) == 1 
 
-		if isArray {
-			arr := make([]interface{}, 0)
-			if content[key] != nil {
-				for _, v := range content[key].([]interface{}) {
-					arr = append(arr, v)
+			if isArray {
+				arr := make([]interface{}, 0)
+				if content[key] != nil {
+					for _, v := range content[key].([]interface{}) {
+						arr = append(arr, v)
+					}
 				}
+				arr = append(arr, v)
+				content[key] = arr
+			} else {
+				content[key] = v
 			}
-			arr = append(arr, v)
-			content[key] = arr
-		} else {
-			content[key] = v
-		}
-		break
-	case C.json_type_string:
-		if isArray {
-			arr := make([]interface{}, 0)
-			if content[key] != nil {
-				for _, v := range content[key].([]interface{}) {
-					arr = append(arr, v)
+			break
+		case C.json_type_string:
+			if isArray {
+				arr := make([]interface{}, 0)
+				if content[key] != nil {
+					for _, v := range content[key].([]interface{}) {
+						arr = append(arr, v)
+					}
 				}
+				arr = append(arr, C.GoString(C.json_object_get_string(jobj)))
+				content[key] = arr
+			} else {
+				 content[key] = C.GoString(C.json_object_get_string(jobj))
 			}
-			arr = append(arr, C.GoString(C.json_object_get_string(jobj)))
-			content[key] = arr
-		} else {
-			 content[key] = C.GoString(C.json_object_get_string(jobj))
-		}
-		break
-	case C.json_type_double:
-		if isArray {
-			arr := make([]interface{}, 0)
-			if content[key] != nil {
-				for _, v := range content[key].([]interface{}) {
-					arr = append(arr, v)
+			break
+		case C.json_type_double:
+			if isArray {
+				arr := make([]interface{}, 0)
+				if content[key] != nil {
+					for _, v := range content[key].([]interface{}) {
+						arr = append(arr, v)
+					}
 				}
+				arr = append(arr, float64(C.json_object_get_double(jobj)))
+				content[key] = arr
+			} else {
+				content[key] = float64(C.json_object_get_double(jobj))
 			}
-			arr = append(arr, float64(C.json_object_get_double(jobj)))
-			content[key] = arr
-		} else {
-			content[key] = float64(C.json_object_get_double(jobj))
-		}
-		break
-	case C.json_type_int:
-		if isArray {
-			arr := make([]interface{}, 0)
-			if content[key] != nil {
-				for _, v := range content[key].([]interface{}) {
-					arr = append(arr, v)
+			break
+		case C.json_type_int:
+			if isArray {
+				arr := make([]interface{}, 0)
+				if content[key] != nil {
+					for _, v := range content[key].([]interface{}) {
+						arr = append(arr, v)
+					}
 				}
+				arr = append(arr, int(C.json_object_get_int(jobj)))
+				content[key] = arr
+			} else {
+				content[key] = int(C.json_object_get_int(jobj))
 			}
-			arr = append(arr, int(C.json_object_get_int(jobj)))
-			content[key] = arr
-		} else {
-			content[key] = int(C.json_object_get_int(jobj))
-		}
-		break
+			break
 	}
 }
 

--- a/cgo/kuzzle/list_collections.go
+++ b/cgo/kuzzle/list_collections.go
@@ -3,7 +3,8 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
@@ -14,7 +15,9 @@ import (
 )
 
 //export kuzzle_wrapper_list_collections
-func kuzzle_wrapper_list_collections(k *C.Kuzzle, result *C.json_result, index *C.char, options *C.query_options) C.int {
+func kuzzle_wrapper_list_collections(k *C.Kuzzle, index *C.char, options *C.query_options) *C.json_result {
+	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -22,19 +25,15 @@ func kuzzle_wrapper_list_collections(k *C.Kuzzle, result *C.json_result, index *
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).ListCollections(C.GoString(index), opts)
 	if err != nil {
-		if err.Error() == "Kuzzle.ListCollections: index required" {
-			return C.int(C.EINVAL)
-		} else {
-			result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
-			return 0
-		}
+		Set_json_result_error(result, err)
+		return result
 	}
 
-	var jsonRes *C.json_object
 	r, _ := json.Marshal(res)
 
-	jsonRes = C.json_tokener_parse(C.CString(string(r)))
-	result.result = jsonRes
+	buffer := C.CString(string(r))
+	result.result = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
 
-	return 0
+	return result
 }

--- a/cgo/kuzzle/list_indexes.go
+++ b/cgo/kuzzle/list_indexes.go
@@ -3,7 +3,9 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
+	#include "sdk_wrappers_internal.h"
 */
 import "C"
 import (
@@ -13,7 +15,9 @@ import (
 )
 
 //export kuzzle_wrapper_list_indexes
-func kuzzle_wrapper_list_indexes(k *C.Kuzzle, result *C.string_array_result, options *C.query_options) {
+func kuzzle_wrapper_list_indexes(k *C.Kuzzle, options *C.query_options) *C.string_array_result {
+	result := (*C.string_array_result)(C.calloc(1, C.sizeof_string_array_result))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -21,19 +25,18 @@ func kuzzle_wrapper_list_indexes(k *C.Kuzzle, result *C.string_array_result, opt
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).ListIndexes(opts)
 	if err != nil {
-		(*result).error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+		Set_string_array_result_error(result, err)
+		return result
 	}
 
-	cArray := C.malloc(C.size_t(len(res)) * C.size_t(unsafe.Sizeof(uintptr(0))))
+	result.result = (**C.char)(C.calloc(C.size_t(len(res)), C.sizeof_char_ptr))
+	result.length = C.ulong(len(res))
+	
+	cArray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(result.result))[:len(res):len(res)]
 
-	a := (*[1<<30 - 1]*C.char)(cArray)
-
-	idx := 0
-	for _, substring := range res {
-		a[idx] = C.CString(substring)
-		idx += 1
+	for i, substring := range res {
+		cArray[i] = C.CString(substring)
 	}
-	a[idx] = nil
 
-	(*result).result = (**C.char)(cArray)
+	return result
 }

--- a/cgo/kuzzle/now.go
+++ b/cgo/kuzzle/now.go
@@ -2,17 +2,18 @@ package main
 
 /*
 	#cgo CFLAGS: -I../../headers
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
 	"github.com/kuzzleio/sdk-go/types"
-	"unsafe"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 )
 
 //export kuzzle_wrapper_now
-func kuzzle_wrapper_now(k *C.Kuzzle, res *C.now_result, options *C.query_options) {
+func kuzzle_wrapper_now(k *C.Kuzzle, options *C.query_options) *C.int_result {
+	result := (*C.int_result)(C.calloc(1, C.sizeof_int_result))
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -20,8 +21,10 @@ func kuzzle_wrapper_now(k *C.Kuzzle, res *C.now_result, options *C.query_options
 
 	time, err := (*kuzzle.Kuzzle)(k.instance).Now(opts)
 	if err != nil {
-		res.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+		Set_int_result_error(result, err)
+		return result
 	}
 
-	res.result = C.double(time)
+	result.result = C.longlong(time)
+	return result
 }

--- a/cgo/kuzzle/query.go
+++ b/cgo/kuzzle/query.go
@@ -97,14 +97,7 @@ func kuzzle_wrapper_query(k *C.Kuzzle, request *C.kuzzle_request, options *C.que
 	res := <-resC
 
 	if res.Error != nil {
-		err := res.Error.(*types.KuzzleError)
-		result.error = C.CString(err.Message)
-		result.status = C.int(err.Status)
-
-		if len(res.Stack) > 0 {
-			result.stack = C.CString(err.Stack)
-		}
-
+		Set_kuzzle_response_error(result, res.Error)
 		return result
 	}
 

--- a/cgo/kuzzle/refresh_index.go
+++ b/cgo/kuzzle/refresh_index.go
@@ -3,17 +3,19 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
 	"github.com/kuzzleio/sdk-go/types"
-	"unsafe"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 )
 
 //export kuzzle_wrapper_refresh_index
-func kuzzle_wrapper_refresh_index(k *C.Kuzzle, res *C.shards, index *C.char, options *C.query_options) {
+func kuzzle_wrapper_refresh_index(k *C.Kuzzle, index *C.char, options *C.query_options) *C.shards {
+	result := (*C.shards)(C.calloc(1, C.sizeof_shards))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -21,10 +23,12 @@ func kuzzle_wrapper_refresh_index(k *C.Kuzzle, res *C.shards, index *C.char, opt
 
 	shards, err := (*kuzzle.Kuzzle)(k.instance).RefreshIndex(C.GoString(index), opts)
 	if err != nil {
-		res.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+		Set_shards_error(result, err)
+		return result
 	}
 
-	res.total = C.int(shards.Total)
-	res.successful = C.int(shards.Successful)
-	res.failed = C.int(shards.Failed)
+	result.total = C.int(shards.Total)
+	result.successful = C.int(shards.Successful)
+	result.failed = C.int(shards.Failed)
+	return result
 }

--- a/cgo/kuzzle/set_auto_refresh.go
+++ b/cgo/kuzzle/set_auto_refresh.go
@@ -3,45 +3,37 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
 	"github.com/kuzzleio/sdk-go/types"
-	"unsafe"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 )
 
 //export kuzzle_wrapper_set_auto_refresh
-func kuzzle_wrapper_set_auto_refresh(k *C.Kuzzle, result *C.bool_result, index *C.char, auto_refresh C.uint, options *C.query_options) C.int {
+func kuzzle_wrapper_set_auto_refresh(k *C.Kuzzle, index *C.char, auto_refresh C.uint, options *C.query_options) *C.bool_result {
+	result := (*C.bool_result)(C.calloc(1, C.sizeof_bool_result))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
 	}
 
-	var autoRefresh bool
-	if auto_refresh == 1 {
-		autoRefresh = true
-	}
+	autoRefresh := auto_refresh != 0
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).SetAutoRefresh(C.GoString(index), autoRefresh, opts)
 	if err != nil {
-		if err.Error() == "Kuzzle.SetAutoRefresh: index required" {
-			return C.int(C.EINVAL)
-		} else {
-			result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
-			return 0
-		}
+		Set_bool_result_error(result, err)
+		return result
 	}
 
-	var r C.uint
 	if res {
-		r = 1
+		result.result = 1
 	} else {
-		r = 0
+		result.result = 0
 	}
 
-	result.result = r
-
-	return 0
+	return result
 }

--- a/cgo/kuzzle/set_error.go
+++ b/cgo/kuzzle/set_error.go
@@ -45,8 +45,19 @@ func Set_ack_response_error(s *C.ack_response, err error) {
   }
 }
 
-// apply a types.KuzzleError on a ack_response* C struct
+// apply a types.KuzzleError on a bool_result* C struct
 func Set_bool_result_error(s *C.bool_result, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a kuzzle_response* C struct
+func Set_kuzzle_response_error(s *C.kuzzle_response, err error) {
   kuzzleError := err.(*types.KuzzleError)
   s.status = C.int(kuzzleError.Status)
   s.error = C.CString(kuzzleError.Message)

--- a/cgo/kuzzle/set_error.go
+++ b/cgo/kuzzle/set_error.go
@@ -1,0 +1,57 @@
+package main
+
+/*
+  #cgo CFLAGS: -I../../../headers
+  #cgo LDFLAGS: -ljson-c
+
+  #include "kuzzle.h"
+*/
+import "C"
+
+import (
+  "github.com/kuzzleio/sdk-go/types"
+)
+
+// apply a types.KuzzleError on a json_result* C struct
+func Set_json_result_error(s *C.json_result, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a token_validity* C struct
+func Set_token_validity_error(s *C.token_validity, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a ack_response* C struct
+func Set_ack_response_error(s *C.ack_response, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a ack_response* C struct
+func Set_bool_result_error(s *C.bool_result, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}

--- a/cgo/kuzzle/set_error.go
+++ b/cgo/kuzzle/set_error.go
@@ -66,3 +66,70 @@ func Set_kuzzle_response_error(s *C.kuzzle_response, err error) {
     s.stack = C.CString(kuzzleError.Stack)
   }
 }
+
+// apply a types.KuzzleError on a statistics* C struct
+func Set_statistics_error(s *C.statistics, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a string_array_result* C struct
+func Set_string_array_result_error(s *C.string_array_result, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a login_result* C struct
+func Set_login_result_error(s *C.login_result, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a int_result* C struct
+func Set_int_result_error(s *C.int_result, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a shards* C struct
+func Set_shards_error(s *C.shards, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+
+// apply a types.KuzzleError on a user* C struct
+func Set_user_error(s *C.user, err error) {
+  kuzzleError := err.(*types.KuzzleError)
+  s.status = C.int(kuzzleError.Status)
+  s.error = C.CString(kuzzleError.Message)
+
+  if len(kuzzleError.Stack) > 0 {
+    s.stack = C.CString(kuzzleError.Stack)
+  }
+}
+

--- a/cgo/kuzzle/set_headers.go
+++ b/cgo/kuzzle/set_headers.go
@@ -14,9 +14,6 @@ func kuzzle_wrapper_set_headers(k *C.Kuzzle, content *C.json_object, replace C.u
 	jp := JsonParser{}
 	jp.Parse(content)
 
-	var r bool
-	if replace == 1 {
-		r = true
-	}
+	r := replace != 0
 	(*kuzzle.Kuzzle)(k.instance).SetHeaders(jp.GetContent(), r)
 }

--- a/cgo/kuzzle/set_options.go
+++ b/cgo/kuzzle/set_options.go
@@ -14,18 +14,14 @@ import (
 func SetQueryOptions(options *C.query_options) (opts types.QueryOptions) {
 	opts = types.NewQueryOptions()
 
-	if options.queuable == 0 {
-		opts.SetQueuable(false)
-	} else {
-		opts.SetQueuable(true)
-	}
+	opts.SetQueuable(options.queuable != 0)
 	opts.SetFrom(int(options.from))
 	opts.SetSize(int(options.size))
-	opts.SetScroll(C.GoString(&options.scroll[0]))
-	opts.SetScrollId(C.GoString(&options.scrollId[0]))
-	opts.SetRefresh(C.GoString(&options.refresh[0]))
-	opts.SetIfExist(C.GoString(&options.ifExist[0]))
-	opts.SetRetryOnConflict(int(options.retryOnConflict))
+	opts.SetScroll(C.GoString(options.scroll))
+	opts.SetScrollId(C.GoString(options.scroll_id))
+	opts.SetRefresh(C.GoString(options.refresh))
+	opts.SetIfExist(C.GoString(options.if_exist))
+	opts.SetRetryOnConflict(int(options.retry_on_conflict))
 
 	out, _ := json.Marshal(opts.GetVolatile())
 	vols := make(map[string]interface{})
@@ -38,39 +34,19 @@ func SetQueryOptions(options *C.query_options) (opts types.QueryOptions) {
 func SetOptions(options *C.Options) (opts types.Options) {
 	opts = types.NewOptions()
 
-	opts.SetQueueTTL(time.Duration(int(options.queue_ttl)))
+	opts.SetQueueTTL(time.Duration(uint16(options.queue_ttl)))
 	opts.SetQueueMaxSize(int(options.queue_max_size))
 	opts.SetOfflineMode(int(options.offline_mode))
 
-	var autoQueue bool
-	if options.auto_queue == 1 {
-		autoQueue = true
-	}
-	opts.SetAutoQueue(autoQueue)
-
-	var autoReconnect bool
-	if options.auto_reconnect == 1 {
-		autoReconnect = true
-	}
-	opts.SetAutoReconnect(autoReconnect)
-
-	var autoReplay bool
-	if options.auto_replay == 1 {
-		autoReplay = true
-	}
-	opts.SetAutoReplay(autoReplay)
-
-	var autoResub bool
-	if options.auto_resubscribe == 1 {
-		autoResub = true
-	}
-	opts.SetAutoResubscribe(autoResub)
-
+	opts.SetAutoQueue(options.auto_queue != 0)
+	opts.SetAutoReconnect(options.auto_reconnect != 0)
+	opts.SetAutoReplay(options.auto_replay != 0)
+	opts.SetAutoResubscribe(options.auto_resubscribe != 0)
 	opts.SetReconnectionDelay(time.Duration(int(options.reconnection_delay)))
 	opts.SetReplayInterval(time.Duration(int(options.replay_interval)))
 	opts.SetConnect(int(options.connect))
-	opts.SetRefresh(C.GoString(&options.refresh[0]))
-	opts.SetDefaultIndex(C.GoString(&options.default_index[0]))
+	opts.SetRefresh(C.GoString(options.refresh))
+	opts.SetDefaultIndex(C.GoString(options.default_index))
 
 	p := JsonParser{}
 	p.Parse(options.headers)

--- a/cgo/kuzzle/update_my_credentials.go
+++ b/cgo/kuzzle/update_my_credentials.go
@@ -3,7 +3,8 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
@@ -14,7 +15,9 @@ import (
 )
 
 //export kuzzle_wrapper_update_my_credentials
-func kuzzle_wrapper_update_my_credentials(k *C.Kuzzle, result *C.json_result, strategy *C.char, credentials *C.json_object, options *C.query_options) C.int {
+func kuzzle_wrapper_update_my_credentials(k *C.Kuzzle, strategy *C.char, credentials *C.json_object, options *C.query_options) *C.json_result {
+	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -25,19 +28,14 @@ func kuzzle_wrapper_update_my_credentials(k *C.Kuzzle, result *C.json_result, st
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).UpdateMyCredentials(C.GoString(strategy), jp.GetContent(), opts)
 	if err != nil {
-		if err.Error() == "Kuzzle.UpdateMyCredentials: strategy is required" {
-			return C.int(C.EINVAL)
-		} else {
-			result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
-			return 0
-		}
+		Set_json_result_error(result, err)
+		return result
 	}
 
-	var jsonRes *C.json_object
 	r, _ := json.Marshal(res)
+	buffer := C.CString(string(r))
+	result.result = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
 
-	jsonRes = C.json_tokener_parse(C.CString(string(r)))
-	result.result = jsonRes
-
-	return 0
+	return result
 }

--- a/cgo/kuzzle/update_self.go
+++ b/cgo/kuzzle/update_self.go
@@ -3,7 +3,8 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
@@ -14,7 +15,9 @@ import (
 )
 
 //export kuzzle_wrapper_update_self
-func kuzzle_wrapper_update_self(k *C.Kuzzle, result *C.json_result, credentials *C.json_object, options *C.query_options) {
+func kuzzle_wrapper_update_self(k *C.Kuzzle, credentials *C.json_object, options *C.query_options) *C.json_result {
+	result := (*C.json_result)(C.calloc(1, C.sizeof_json_result))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -25,12 +28,14 @@ func kuzzle_wrapper_update_self(k *C.Kuzzle, result *C.json_result, credentials 
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).UpdateSelf(jp.GetContent(), opts)
 	if err != nil {
-		result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+		Set_json_result_error(result, err)
+		return result
 	}
 
-	var jsonRes *C.json_object
 	r, _ := json.Marshal(res)
+	buffer := C.CString(string(r))
+	result.result = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
 
-	jsonRes = C.json_tokener_parse(C.CString(string(r)))
-	result.result = jsonRes
+	return result
 }

--- a/cgo/kuzzle/validate_my_credentials.go
+++ b/cgo/kuzzle/validate_my_credentials.go
@@ -3,17 +3,19 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
 */
 import "C"
 import (
 	"github.com/kuzzleio/sdk-go/types"
-	"unsafe"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 )
 
 //export kuzzle_wrapper_validate_my_credentials
-func kuzzle_wrapper_validate_my_credentials(k *C.Kuzzle, result *C.bool_result, strategy *C.char, credentials *C.json_object, options *C.query_options) {
+func kuzzle_wrapper_validate_my_credentials(k *C.Kuzzle, strategy *C.char, credentials *C.json_object, options *C.query_options) *C.bool_result {
+	result := (*C.bool_result)(C.calloc(1, C.sizeof_bool_result))
+
 	var opts types.QueryOptions
 	if options != nil {
 		opts = SetQueryOptions(options)
@@ -24,14 +26,15 @@ func kuzzle_wrapper_validate_my_credentials(k *C.Kuzzle, result *C.bool_result, 
 
 	res, err := (*kuzzle.Kuzzle)(k.instance).ValidateMyCredentials(C.GoString(strategy), jp.GetContent(), opts)
 	if err != nil {
-		result.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+		Set_bool_result_error(result, err)
+		return result
 	}
 
-	var r C.uint
 	if res {
-		r = 1
+		result.result = 1
 	} else {
-		r = 0
+		result.result = 0
 	}
-	result.result = r
+	
+	return result
 }

--- a/cgo/kuzzle/who_am_i.go
+++ b/cgo/kuzzle/who_am_i.go
@@ -3,7 +3,9 @@ package main
 /*
 	#cgo CFLAGS: -I../../headers
 	#cgo LDFLAGS: -ljson-c
-	#include <kuzzle.h>
+	#include <stdlib.h>
+	#include "kuzzle.h"
+	#include "sdk_wrappers_internal.h"
 */
 import "C"
 import (
@@ -12,41 +14,41 @@ import (
 )
 
 //export kuzzle_wrapper_who_am_i
-func kuzzle_wrapper_who_am_i(k *C.Kuzzle, user *C.user) {
+func kuzzle_wrapper_who_am_i(k *C.Kuzzle) *C.user {
+	user := (*C.user)(C.calloc(1, C.sizeof_user))
+
 	res, err := (*kuzzle.Kuzzle)(k.instance).WhoAmI()
 	if err != nil {
-		user.error = *(*[2048]C.char)(unsafe.Pointer(C.CString(err.Error())))
+		Set_user_error(user, err)
+		return user
 	}
 
-	var meta C.kuzzle_meta
-	var active C.uint
-	meta.author = *(*[512]C.char)(unsafe.Pointer(C.CString(res.Meta.Author)))
-	meta.created_at = C.int(res.Meta.CreatedAt)
-	meta.updated_at = C.int(res.Meta.UpdatedAt)
-	meta.updater = *(*[512]C.char)(unsafe.Pointer(C.CString(res.Meta.Updater)))
+	user.meta = (*C.kuzzle_meta)(C.calloc(1, C.sizeof_kuzzle_meta))
+	user.meta.author = C.CString(res.Meta.Author)
+	user.meta.created_at = C.ulonglong(res.Meta.CreatedAt)
+	user.meta.updated_at = C.ulonglong(res.Meta.UpdatedAt)
+	user.meta.deleted_at = C.ulonglong(res.Meta.DeletedAt)
+	user.meta.updater = C.CString(res.Meta.Updater)
 
 	if res.Meta.Active {
-		active = 1
+		user.meta.active = 1
 	} else {
-		active = 0
+		user.meta.active = 0
 	}
-	meta.active = active
-	meta.deleted_at = C.int(res.Meta.DeletedAt)
 
-	var source *C.json_object
-	source = C.json_tokener_parse(C.CString(string(res.Source)))
+	buffer := C.CString(string(res.Source))
+	user.source = C.json_tokener_parse(buffer)
+	C.free(unsafe.Pointer(buffer))
 
-	cArray := C.malloc(C.size_t(len(res.Strategies)) * C.size_t(unsafe.Sizeof(uintptr(0))))
-	a := (*[1<<30 - 1]*C.char)(cArray)
-	idx := 0
-	for _, substring := range res.Strategies {
-		a[idx] = C.CString(substring)
-		idx += 1
+	user.strategies_length = C.ulong(len(res.Strategies))
+	user.strategies = (**C.char)(C.calloc(C.size_t(user.strategies_length), C.sizeof_char_ptr))
+	cArray := (*[1<<30 - 1]*C.char)(unsafe.Pointer(user.strategies))[:len(res.Strategies):len(res.Strategies)]
+
+	for i, substring := range res.Strategies {
+		cArray[i] = C.CString(substring)
 	}
-	a[idx] = nil
 
-	user.id = *(*[512]C.char)(unsafe.Pointer(C.CString(res.Id)))
-	user.source = source
-	user.meta = &meta
-	user.strategies = (**C.char)(cArray)
+	user.id = C.CString(res.Id)
+
+	return user
 }

--- a/headers/kuzzle.h
+++ b/headers/kuzzle.h
@@ -6,7 +6,7 @@
 #include <errno.h>
 
 typedef struct {
-    void* instance;
+    void *instance;
 } Kuzzle;
 
 enum {
@@ -25,75 +25,75 @@ enum {
 
 //define a request
 typedef struct {
-    char request_id[36];
-    char controller[128];
-    char action[128];
-    char index[128];
-    char collection[128];
+    char *request_id;
+    char *controller;
+    char *action;
+    char *index;
+    char *collection;
     json_object *body;
-    char id[128];
+    char *id;
     int from;
     int size;
-    char scroll[32];
-    char scroll_id[128];
-    char strategy[128];
+    char *scroll;
+    char *scroll_id;
+    char *strategy;
     int expires_in;
-    json_object* volatiles;
-    char scope[512];
-    char state[512];
-    char user[512];
+    json_object *volatiles;
+    char *scope;
+    char *state;
+    char *user;
     int start;
     int stop;
     int end;
     int bit;
-    char member[512];
-    char member1[512];
-    char member2[512];
+    char *member;
+    char *member1;
+    char *member2;
     char **members;
     float lon;
     float lat;
     float distance;
-    char unit[128];
-    json_object* options;
+    char *unit;
+    json_object *options;
     char **keys;
     int cursor;
     int offset;
-    char field[512];
+    char *field;
     char **fields;
-    char subcommand[1024];
-    char pattern[1024];
+    char *subcommand;
+    char *pattern;
     int idx;
-    char min[512];
-    char max[512];
-    char limit[512];
+    char *min;
+    char *max;
+    char *limit;
     int count;
-    char match[512];
+    char *match;
 } kuzzle_request;
 
 //query object used by query()
 typedef struct {
     json_object *query;
     unsigned long long   timestamp;
-    char   request_id[36];
+    char   *request_id;
 } query_object;
 
 typedef struct {
-    query_object** query;
+    query_object **query;
 } offline_queue;
 
 //response of check_token()
 typedef struct token_validity_struct {
     unsigned valid;
-    char state[512];
+    char *state;
     int expiresAt;
-    char error[2048];
+    char *error;
 } token_validity;
 
 //response for any delete* function
 typedef struct ack_response_struct {
     unsigned acknowledged;
     unsigned shardsAcknowledged;
-    char error[2048];
+    char *error;
 } ack_response;
 
 //options passed to query()
@@ -101,11 +101,11 @@ typedef struct {
     unsigned queuable;
     int from;
     int size;
-    char scroll[16];
-    char scrollId[128];
-    char refresh[32];
-    char ifExist[32];
-    int retryOnConflict;
+    char *scroll;
+    char *scroll_id;
+    char *refresh;
+    char *if_exist;
+    int retry_on_conflict;
     json_object *volatiles;
 } query_options;
 
@@ -122,33 +122,33 @@ typedef struct {
     double reconnection_delay;
     double replay_interval;
     enum Mode connect;
-    char refresh[64];
-    char default_index[128];
+    char *refresh;
+    char *default_index;
     json_object    *headers;
 } Options;
 
 //result of login()
 typedef struct {
-    char jwt[512];
-    char error[2048];
+    char *jwt;
+    char *error;
 } login_result;
 
 //any json result
 typedef struct {
     json_object *result;
-    char error[2048];
+    char *error;
 } json_result;
 
 //used for any boolean result
 typedef struct {
     unsigned result;
-    char error[2048];
+    char *error;
 } bool_result;
 
 //used for now result
 typedef struct {
     double result;
-    char error[2048];
+    char *error;
 } now_result;
 
 //used for get_statistics
@@ -158,13 +158,13 @@ typedef struct {
     json_object* failed_requests;
     json_object* ongoing_requests;
     double timestamp;
-    char error[2048];
+    char *error;
 } statistics;
 
 //used for string array result
 typedef struct {
     char **result;
-    char error[2048];
+    char *error;
 } string_array_result;
 
 //used for refresh_index
@@ -172,34 +172,34 @@ typedef struct {
     int total;
     int successful;
     int failed;
-    char error[2048];
+    char *error;
 } shards;
 
 //meta of a document
 typedef struct {
-    char author[512];
+    char *author;
     int created_at;
     int updated_at;
-    char updater[512];
+    char *updater;
     unsigned active;
     int deleted_at;
 } kuzzle_meta;
 
 //kuzzle user
 typedef struct {
-    char id[512];
+    char *id;
     json_object* source;
     kuzzle_meta* meta;
     char **strategies;
-    char error[2048];
+    char *error;
 } user;
 
 typedef struct {
-    char request_id[36];
-    json_object* result;
-    char room_id[36];
-    char channel[128];
-    char error[2048];
+    char *request_id;
+    json_object *result;
+    char *room_id;
+    char *channel;
+    char *error;
 } kuzzle_response;
 
 // Kuzzle main object functions
@@ -207,7 +207,7 @@ extern void kuzzle_wrapper_new_kuzzle(Kuzzle*, char*, char*, Options*);
 extern char* kuzzle_wrapper_connect(Kuzzle*);
 extern void kuzzle_wrapper_get_offline_queue(Kuzzle*, offline_queue*);
 extern char* kuzzle_wrapper_get_jwt(Kuzzle*);
-extern int kuzzle_wrapper_check_token(Kuzzle*, token_validity*, char*);
+extern token_validity* kuzzle_wrapper_check_token(Kuzzle*, char*);
 extern int kuzzle_wrapper_create_index(Kuzzle*, ack_response*, char*, query_options*);
 extern int kuzzle_wrapper_login(Kuzzle*, login_result*, char*, json_object*, int*);
 extern int kuzzle_wrapper_create_my_credentials(Kuzzle*, json_result*, char*, json_object*, query_options*);

--- a/headers/kuzzle.h
+++ b/headers/kuzzle.h
@@ -32,41 +32,44 @@ typedef struct {
     char *collection;
     json_object *body;
     char *id;
-    int from;
-    int size;
+    long from;
+    long size;
     char *scroll;
     char *scroll_id;
     char *strategy;
-    int expires_in;
+    unsigned long expires_in;
     json_object *volatiles;
     char *scope;
     char *state;
     char *user;
-    int start;
-    int stop;
-    int end;
-    int bit;
+    long start;
+    long stop;
+    long end;
+    unsigned char bit;
     char *member;
     char *member1;
     char *member2;
     char **members;
-    float lon;
-    float lat;
-    float distance;
+    unsigned members_length;
+    double lon;
+    double lat;
+    double distance;
     char *unit;
     json_object *options;
     char **keys;
-    int cursor;
-    int offset;
+    unsigned keys_length;
+    long cursor;
+    long offset;
     char *field;
     char **fields;
+    unsigned fields_length;
     char *subcommand;
     char *pattern;
-    int idx;
+    long idx;
     char *min;
     char *max;
     char *limit;
-    int count;
+    unsigned long count;
     char *match;
 } kuzzle_request;
 
@@ -78,35 +81,36 @@ typedef struct {
 } query_object;
 
 typedef struct {
-    query_object **query;
+    query_object **queries;
+    unsigned long length;
 } offline_queue;
 
 
 //options passed to query()
 typedef struct {
     unsigned queuable;
-    int from;
-    int size;
+    long from;
+    long size;
     char *scroll;
     char *scroll_id;
     char *refresh;
     char *if_exist;
-    int retry_on_conflict;
+    unsigned char retry_on_conflict;
     json_object *volatiles;
 } query_options;
 
 enum Mode {AUTO, MANUAL};
 //options passed to the Kuzzle() fct
 typedef struct {
-    double queue_ttl;
-    int queue_max_size;
-    int offline_mode;
-    unsigned auto_queue;
-    unsigned auto_reconnect;
-    unsigned auto_replay;
-    unsigned auto_resubscribe;
-    double reconnection_delay;
-    double replay_interval;
+    unsigned queue_ttl;
+    unsigned long queue_max_size;
+    unsigned char offline_mode;
+    unsigned char auto_queue;
+    unsigned char auto_reconnect;
+    unsigned char auto_replay;
+    unsigned char auto_resubscribe;
+    unsigned long reconnection_delay;
+    unsigned long replay_interval;
     enum Mode connect;
     char *refresh;
     char *default_index;
@@ -116,11 +120,11 @@ typedef struct {
 //meta of a document
 typedef struct {
     char *author;
-    int created_at;
-    int updated_at;
+    unsigned long long created_at;
+    unsigned long long updated_at;
     char *updater;
-    unsigned active;
-    int deleted_at;
+    unsigned char active;
+    unsigned long long deleted_at;
 } kuzzle_meta;
 
 //kuzzle user
@@ -129,8 +133,10 @@ typedef struct {
     json_object* source;
     kuzzle_meta* meta;
     char **strategies;
+    unsigned long strategies_length;
     int status;
     char *error;
+    char *stack;
 } user;
 
 /* === Dedicated response structures === */
@@ -144,6 +150,7 @@ typedef struct {
     unsigned long long timestamp;
     int status;
     char *error;
+    char *stack;
 } statistics;
 
 //check_token
@@ -170,6 +177,7 @@ typedef struct {
     char *jwt;
     int status;
     char *error;
+    char *stack;
 } login_result;
 
 //refresh_index
@@ -179,6 +187,7 @@ typedef struct {
     int failed;
     int status;
     char *error;
+    char *stack;
 } shards;
 
 /* === Generic response structures === */
@@ -215,44 +224,47 @@ typedef struct {
     long long result;
     int status;
     char *error;
-} now_result;
+    char *stack;
+} int_result;
 
-//used for string array result
+//any array of strings result
 typedef struct {
     char **result;
+    unsigned long length;
     int status;
     char *error;
+    char *stack;
 } string_array_result;
 
 
 // Kuzzle main object functions
 extern void kuzzle_wrapper_new_kuzzle(Kuzzle*, char*, char*, Options*);
 extern char* kuzzle_wrapper_connect(Kuzzle*);
-extern void kuzzle_wrapper_get_offline_queue(Kuzzle*, offline_queue*);
+extern offline_queue* kuzzle_wrapper_get_offline_queue(Kuzzle*);
 extern char* kuzzle_wrapper_get_jwt(Kuzzle*);
 extern token_validity* kuzzle_wrapper_check_token(Kuzzle*, char*);
 extern ack_response* kuzzle_wrapper_create_index(Kuzzle*, char*, query_options*);
-extern int kuzzle_wrapper_login(Kuzzle*, login_result*, char*, json_object*, int*);
+extern login_result* kuzzle_wrapper_login(Kuzzle*, char*, json_object*, int*);
 extern json_result* kuzzle_wrapper_create_my_credentials(Kuzzle*, char*, json_object*, query_options*);
 extern void kuzzle_wrapper_disconnect(Kuzzle*);
 extern void kuzzle_wrapper_flush_queue(Kuzzle*);
 extern json_result* kuzzle_wrapper_get_all_statistics(Kuzzle*, query_options*);
 extern bool_result* kuzzle_wrapper_get_auto_refresh(Kuzzle*, char*, query_options*);
 extern json_result* kuzzle_wrapper_get_my_credentials(Kuzzle*, char*, query_options*);
-extern json_result kuzzle_wrapper_get_my_rights(Kuzzle*, query_options*);
+extern json_result* kuzzle_wrapper_get_my_rights(Kuzzle*, query_options*);
 extern json_result* kuzzle_wrapper_get_server_info(Kuzzle*, query_options*);
-extern void kuzzle_wrapper_get_statistics(Kuzzle*, statistics*, time_t, query_options*);
-extern int kuzzle_wrapper_list_collections(Kuzzle*, json_result*, char*, query_options*);
-extern void kuzzle_wrapper_list_indexes(Kuzzle*, string_array_result*, query_options*);
+extern statistics* kuzzle_wrapper_get_statistics(Kuzzle*, time_t, query_options*);
+extern json_result* kuzzle_wrapper_list_collections(Kuzzle*, char*, query_options*);
+extern string_array_result* kuzzle_wrapper_list_indexes(Kuzzle*, query_options*);
 extern char* kuzzle_wrapper_logout(Kuzzle*);
-extern void kuzzle_wrapper_now(Kuzzle*, now_result*, query_options*);
-extern void kuzzle_wrapper_refresh_index(Kuzzle*, shards*, char*, query_options*);
-extern int kuzzle_wrapper_set_auto_refresh(Kuzzle*, bool_result*, char*, unsigned, query_options*);
+extern int_result* kuzzle_wrapper_now(Kuzzle*, query_options*);
+extern shards* kuzzle_wrapper_refresh_index(Kuzzle*, char*, query_options*);
+extern bool_result* kuzzle_wrapper_set_auto_refresh(Kuzzle*, char*, unsigned, query_options*);
 extern int kuzzle_wrapper_set_default_index(Kuzzle*, char*);
 extern void kuzzle_wrapper_unset_jwt(Kuzzle*);
-extern void kuzzle_wrapper_update_self(Kuzzle*, json_result*, json_object*, query_options*);
-extern void kuzzle_wrapper_validate_my_credentials(Kuzzle*, bool_result*, char*, json_object*, query_options*);
-extern void kuzzle_wrapper_who_am_i(Kuzzle*, user*);
+extern json_result* kuzzle_wrapper_update_self(Kuzzle*, json_object*, query_options*);
+extern bool_result* kuzzle_wrapper_validate_my_credentials(Kuzzle*, char*, json_object*, query_options*);
+extern user* kuzzle_wrapper_who_am_i(Kuzzle*);
 extern kuzzle_response* kuzzle_wrapper_query(Kuzzle*, kuzzle_request*, query_options*);
 extern void kuzzle_wrapper_set_headers(Kuzzle*, json_object*, unsigned);
 extern json_object* kuzzle_wrapper_get_headers(Kuzzle*);
@@ -263,8 +275,8 @@ extern void kuzzle_wrapper_set_jwt(Kuzzle*, char*);
 extern void kuzzle_wrapper_start_queuing(Kuzzle*);
 extern void kuzzle_wrapper_stop_queuing(Kuzzle*);
 extern ack_response* kuzzle_wrapper_delete_my_credentials(Kuzzle*, char*, query_options*);
-
+extern json_result* kuzzle_wrapper_update_my_credentials(Kuzzle*, char*, json_object*, query_options*);
 //Options
-extern void kuzzle_wrapper_new_options(Options*);
+extern Options* kuzzle_wrapper_new_options(void);
 
 #endif

--- a/headers/sdk_wrappers_internal.h
+++ b/headers/sdk_wrappers_internal.h
@@ -1,0 +1,6 @@
+#ifndef __SDK_WRAPPERS_INTERNAL
+#define __SDK_WRAPPERS_INTERNAL
+
+typedef char *char_ptr;
+
+#endif


### PR DESCRIPTION
# Description

C structures contain arbitrary large array objects, making each request + response to Kuzzle takes at least 10kB on the stack.

All these static arrays have been converted to pointers, allocated only when needed.
Since now structures contain pointers, we need to allocate them ourselves, and cannot take pre-allocated structures as arguments, since we cannot know what to do when needing to overwrite a non-NULL pointer: deallocate it first at the risk of freeing unmapped memory, or overwrite at the risk of creating a dangling pointer?

To prevent these problems, now all methods returning a result structure allocate and return it.

# Other changes

* solves many memleaks and dangling pointers
* solves go pointers leaking into C code, leading to undefined behaviors
* all response structures now contain the following properties: `status` (int, error code), `error` (char*, error message), `stack` (char*, error stack trace)
* fix structure properties datatypes (e.g. timestamps are now `unsigned long long` instead of `double`)
* fix missing methods exposed in `kuzzle.h`
* array of arrays are no longer NULL-terminated, but instead a `<array name>_length` property has been added for each of these, so that there is no need to go through the entire array to know its length