### PR TITLE
Harmonize values returned by memory storage functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # IDE
 .idea
 
-# Libgokcore
-libgokcore.*
+# Auto-generated library
+kuzzle.h
+libkuzzlesdk.so
 
 # .out files
 *.out

--- a/cgo/kuzzle/errors.go
+++ b/cgo/kuzzle/errors.go
@@ -135,6 +135,10 @@ func Set_notification_result_error(s *C.notification_result, err error) {
 	setErr(&s.status, s.error, s.stack, err)
 }
 
+func Set_void_result_error(s *C.void_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
 func setErr(status *C.int, error *C.char, stack *C.char, err error) {
 	kuzzleError := err.(*types.KuzzleError)
 	*status = C.int(kuzzleError.Status)

--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -743,3 +743,15 @@ func goToCStatistics(res *types.Statistics, err error) *C.statistics {
 
 	return result
 }
+
+// Allocates memory
+func goToCVoidResult(err error) *C.void_result {
+	if err == nil {
+		return nil
+	}
+
+	result := (*C.void_result)(C.calloc(1, C.sizeof_void_result))
+	Set_void_result_error(result, err)
+
+	return result
+}

--- a/cgo/kuzzle/memory_storage.go
+++ b/cgo/kuzzle/memory_storage.go
@@ -108,30 +108,30 @@ func kuzzle_wrapper_ms_exists(k *C.kuzzle, keys **C.char, klen C.uint, options *
 }
 
 //export kuzzle_wrapper_ms_expire
-func kuzzle_wrapper_ms_expire(k *C.kuzzle, key *C.char, seconds C.ulong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_expire(k *C.kuzzle, key *C.char, seconds C.ulong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Expire(
 		C.GoString(key),
 		int(seconds),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_expireat
-func kuzzle_wrapper_ms_expireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_expireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Expireat(
 		C.GoString(key),
 		int(ts),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_flushdb
-func kuzzle_wrapper_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Flushdb(SetQueryOptions(options))
+func kuzzle_wrapper_ms_flushdb(k *C.kuzzle, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Flushdb(SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_geoadd
@@ -296,13 +296,13 @@ func kuzzle_wrapper_ms_hdel(k *C.kuzzle, key *C.char, fields **C.char, flen C.ui
 }
 
 //export kuzzle_wrapper_ms_hexists
-func kuzzle_wrapper_ms_hexists(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hexists(k *C.kuzzle, key *C.char, field *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hexists(
 		C.GoString(key),
 		C.GoString(field),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_hget
@@ -387,7 +387,7 @@ func kuzzle_wrapper_ms_hmget(k *C.kuzzle, key *C.char, fields **C.char, flen C.u
 }
 
 //export kuzzle_wrapper_ms_hmset
-func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, elen C.uint, options *C.query_options) *C.string_result {
+func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, elen C.uint, options *C.query_options) *C.void_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MsHashField, int(elen))
 
@@ -397,12 +397,12 @@ func kuzzle_wrapper_ms_hmset(k *C.kuzzle, key *C.char, entries **C.json_object, 
 		json.Unmarshal(gobytes, goentries[i])
 	}
 
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmset(
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hmset(
 		C.GoString(key),
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_hscan
@@ -416,25 +416,25 @@ func kuzzle_wrapper_ms_hscan(k *C.kuzzle, key *C.char, cursor C.int, options *C.
 }
 
 //export kuzzle_wrapper_ms_hset
-func kuzzle_wrapper_ms_hset(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hset(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hset(
 		C.GoString(key),
 		C.GoString(field),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_hsetnx
-func kuzzle_wrapper_ms_hsetnx(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_hsetnx(k *C.kuzzle, key *C.char, field *C.char, value *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Hsetnx(
 		C.GoString(key),
 		C.GoString(field),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_hstrlen
@@ -577,25 +577,25 @@ func kuzzle_wrapper_ms_lrem(k *C.kuzzle, key *C.char, count C.long, value *C.cha
 }
 
 //export kuzzle_wrapper_ms_lset
-func kuzzle_wrapper_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lset(
+func kuzzle_wrapper_ms_lset(k *C.kuzzle, key *C.char, index C.long, value *C.char, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Lset(
 		C.GoString(key),
 		int(index),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_ltrim
-func kuzzle_wrapper_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ltrim(
+func kuzzle_wrapper_ms_ltrim(k *C.kuzzle, key *C.char, start C.long, stop C.long, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Ltrim(
 		C.GoString(key),
 		int(start),
 		int(stop),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_mget
@@ -618,7 +618,7 @@ func kuzzle_wrapper_ms_mget(k *C.kuzzle, keys **C.char, klen C.uint, options *C.
 }
 
 //export kuzzle_wrapper_ms_mset
-func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.string_result {
+func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.void_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MSKeyValue, int(elen))
 
@@ -628,15 +628,15 @@ func kuzzle_wrapper_ms_mset(k *C.kuzzle, entries **C.json_object, elen C.uint, o
 		json.Unmarshal(gobytes, goentries[i])
 	}
 
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mset(
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Mset(
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_msetnx
-func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.uint, options *C.query_options) *C.bool_result {
 	wrapped := (*[1 << 20]*C.json_object)(unsafe.Pointer(entries))[:elen:elen]
 	goentries := make([]*types.MSKeyValue, int(elen))
 
@@ -650,7 +650,7 @@ func kuzzle_wrapper_ms_msetnx(k *C.kuzzle, entries **C.json_object, elen C.uint,
 		goentries,
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_object
@@ -664,42 +664,42 @@ func kuzzle_wrapper_ms_object(k *C.kuzzle, key *C.char, subcommand *C.char, opti
 }
 
 //export kuzzle_wrapper_ms_persist
-func kuzzle_wrapper_ms_persist(k *C.kuzzle, key *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_persist(k *C.kuzzle, key *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Persist(
 		C.GoString(key),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pexpire
-func kuzzle_wrapper_ms_pexpire(k *C.kuzzle, key *C.char, ttl C.ulong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pexpire(k *C.kuzzle, key *C.char, ttl C.ulong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pexpire(
 		C.GoString(key),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pexpireat
-func kuzzle_wrapper_ms_pexpireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pexpireat(k *C.kuzzle, key *C.char, ts C.ulonglong, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pexpireat(
 		C.GoString(key),
 		int(ts),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pfadd
-func kuzzle_wrapper_ms_pfadd(k *C.kuzzle, key *C.char, elements **C.char, elen C.uint, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_pfadd(k *C.kuzzle, key *C.char, elements **C.char, elen C.uint, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfadd(
 		C.GoString(key),
 		cToGoStrings(elements, elen),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_pfcount
@@ -712,13 +712,13 @@ func kuzzle_wrapper_ms_pfcount(k *C.kuzzle, keys **C.char, klen C.uint, options 
 }
 
 //export kuzzle_wrapper_ms_pfmerge
-func kuzzle_wrapper_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.uint, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfmerge(
+func kuzzle_wrapper_ms_pfmerge(k *C.kuzzle, key *C.char, sources **C.char, slen C.uint, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Pfmerge(
 		C.GoString(key),
 		cToGoStrings(sources, slen),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_ping
@@ -730,14 +730,14 @@ func kuzzle_wrapper_ms_ping(k *C.kuzzle, options *C.query_options) *C.string_res
 }
 
 //export kuzzle_wrapper_ms_psetex
-func kuzzle_wrapper_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Psetex(
+func kuzzle_wrapper_ms_psetex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Psetex(
 		C.GoString(key),
 		C.GoString(value),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_pttl
@@ -758,23 +758,23 @@ func kuzzle_wrapper_ms_randomkey(k *C.kuzzle, options *C.query_options) *C.strin
 }
 
 //export kuzzle_wrapper_ms_rename
-func kuzzle_wrapper_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rename(
+func kuzzle_wrapper_ms_rename(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Rename(
 		C.GoString(key),
 		C.GoString(newkey),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_renamenx
-func kuzzle_wrapper_ms_renamenx(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_renamenx(k *C.kuzzle, key *C.char, newkey *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Renamenx(
 		C.GoString(key),
 		C.GoString(newkey),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_rpop
@@ -866,34 +866,34 @@ func kuzzle_wrapper_ms_sdiffstore(k *C.kuzzle, key *C.char, keys **C.char, klen 
 }
 
 //export kuzzle_wrapper_ms_set
-func kuzzle_wrapper_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Set(
+func kuzzle_wrapper_ms_set(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Set(
 		C.GoString(key),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_setex
-func kuzzle_wrapper_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.string_result {
-	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setex(
+func kuzzle_wrapper_ms_setex(k *C.kuzzle, key *C.char, value *C.char, ttl C.ulong, options *C.query_options) *C.void_result {
+	err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setex(
 		C.GoString(key),
 		C.GoString(value),
 		int(ttl),
 		SetQueryOptions(options))
 
-	return goToCStringResult(&res, err)
+	return goToCVoidResult(err)
 }
 
 //export kuzzle_wrapper_ms_setnx
-func kuzzle_wrapper_ms_setnx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_setnx(k *C.kuzzle, key *C.char, value *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Setnx(
 		C.GoString(key),
 		C.GoString(value),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_sinter
@@ -916,13 +916,13 @@ func kuzzle_wrapper_ms_sinterstore(k *C.kuzzle, dest *C.char, keys **C.char, kle
 }
 
 //export kuzzle_wrapper_ms_sismember
-func kuzzle_wrapper_ms_sismember(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_sismember(k *C.kuzzle, key *C.char, member *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Sismember(
 		C.GoString(key),
 		C.GoString(member),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_smembers
@@ -935,14 +935,14 @@ func kuzzle_wrapper_ms_smembers(k *C.kuzzle, key *C.char, options *C.query_optio
 }
 
 //export kuzzle_wrapper_ms_smove
-func kuzzle_wrapper_ms_smove(k *C.kuzzle, key *C.char, dest *C.char, member *C.char, options *C.query_options) *C.int_result {
+func kuzzle_wrapper_ms_smove(k *C.kuzzle, key *C.char, dest *C.char, member *C.char, options *C.query_options) *C.bool_result {
 	res, err := (*kuzzle.Kuzzle)(k.instance).MemoryStorage.Smove(
 		C.GoString(key),
 		C.GoString(dest),
 		C.GoString(member),
 		SetQueryOptions(options))
 
-	return goToCIntResult(res, err)
+	return goToCBoolResult(res, err)
 }
 
 //export kuzzle_wrapper_ms_sort

--- a/headers/kuzzlesdk.h
+++ b/headers/kuzzlesdk.h
@@ -356,6 +356,13 @@ typedef struct {
     char *stack;
 } kuzzle_response;
 
+//any void result
+typedef struct {
+    int status;
+    char *error;
+    char *stack;
+} void_result;
+
 //any json result
 typedef struct {
     json_object *result;


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-go/pull/95 (travis will need to be restarted after the Go SDK PR has been merged) :warning: 

* MS functions returning either `0` or `1` are now resolving to a `bool_result` structure value instead of an `int_result` one
* MS functions returning `"OK"` now returns either `NULL` if the API call completed successfully, or a new `void_result` structure containing the usual error message and status 