### PR TITLE
struct lists as single pointers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ libgokcore.*
 
 # .out files
 *.out
+
+# build
+/kcore_wrap.c
+/kcore_wrap.o
+/kuzzle.h
+/libkuzzle.so
+/libkuzzlesdk.so
+

--- a/cgo/kuzzle/document.go
+++ b/cgo/kuzzle/document.go
@@ -13,7 +13,7 @@ import (
 
 //export kuzzle_wrapper_new_document
 func kuzzle_wrapper_new_document(c *C.collection) *C.document {
-	return goToCDocument(c, cToGoCollection(c).Document())
+	return goToCDocument(c, cToGoCollection(c).Document(), nil)
 }
 
 //export kuzzle_wrapper_document_subscribe

--- a/cgo/kuzzle/errors.go
+++ b/cgo/kuzzle/errors.go
@@ -119,6 +119,10 @@ func Set_search_roles_result_error(s *C.search_roles_result, err error) {
 	setErr(&s.status, s.error, s.stack, err)
 }
 
+func Set_search_users_result_error(s *C.search_users_result, err error) {
+	setErr(&s.status, s.error, s.stack, err)
+}
+
 func Set_user_result_error(s *C.user_result, err error) {
 	setErr(&s.status, s.error, s.stack, err)
 }

--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -48,8 +48,13 @@ func goToCShards(gShards *types.Shards) *C.shards {
 }
 
 // Allocates memory
-func goToCDocument(col *C.collection, gDoc *collection.Document) *C.document {
-	result := (*C.document)(C.calloc(1, C.sizeof_document))
+func goToCDocument(col *C.collection, gDoc *collection.Document, dest *C.document) *C.document {
+	var result *C.document
+	if dest == nil {
+		result = (*C.document)(C.calloc(1, C.sizeof_document))
+	} else {
+		result = dest
+	}
 
 	result.id = C.CString(gDoc.Id)
 	result.index = C.CString(gDoc.Index)
@@ -160,13 +165,18 @@ func goToCDocumentResult(col *C.collection, goRes *collection.Document, err erro
 		return result
 	}
 
-	result.result = goToCDocument(col, goRes)
+	result.result = goToCDocument(col, goRes, nil)
 
 	return result
 }
 
-func goToCPolicyRestriction(restriction *types.PolicyRestriction) *C.policy_restriction {
-	crestriction := (*C.policy_restriction)(C.calloc(1, C.sizeof_policy_restriction))
+func goToCPolicyRestriction(restriction *types.PolicyRestriction, dest *C.policy_restriction) *C.policy_restriction {
+	var crestriction *C.policy_restriction
+	if dest == nil {
+		crestriction = (*C.policy_restriction)(C.calloc(1, C.sizeof_policy_restriction))
+	} else {
+		crestriction = dest
+	}
 	crestriction.index = C.CString(restriction.Index)
 	crestriction.collections_length = C.int(len(restriction.Collections))
 
@@ -271,35 +281,46 @@ func goToCDoubleResult(goRes float64, err error) *C.double_result {
 	return result
 }
 
-func goToCPolicy(policy *types.Policy) *C.policy {
-	cpolicy := (*C.policy)(C.calloc(1, C.sizeof_policy))
+func goToCPolicy(policy *types.Policy, dest *C.policy) *C.policy {
+	var cpolicy *C.policy
+	if dest == nil {
+		cpolicy = (*C.policy)(C.calloc(1, C.sizeof_policy))
+	} else {
+		cpolicy = dest
+	}
+
 	cpolicy.role_id = C.CString(policy.RoleId)
 	cpolicy.restricted_to_length = C.int(len(policy.RestrictedTo))
 
 	if policy.RestrictedTo != nil {
-		cpolicy.restricted_to = (**C.policy_restriction)(C.calloc(C.size_t(len(policy.RestrictedTo)), C.sizeof_policy_restriction_ptr))
-		restrictions := (*[1<<30 - 1]*C.policy_restriction)(unsafe.Pointer(cpolicy.restricted_to))[:len(policy.RestrictedTo)]
+		cpolicy.restricted_to = (*C.policy_restriction)(C.calloc(C.size_t(len(policy.RestrictedTo)), C.sizeof_policy_restriction))
+		restrictions := (*[1<<30 - 1]C.policy_restriction)(unsafe.Pointer(cpolicy.restricted_to))[:len(policy.RestrictedTo)]
 
 		for i, restriction := range policy.RestrictedTo {
-			restrictions[i] = goToCPolicyRestriction(restriction)
+			goToCPolicyRestriction(restriction, &restrictions[i])
 		}
 	}
 
 	return cpolicy
 }
 
-func goToCProfile(k *C.kuzzle, profile *security.Profile) *C.profile {
-	cprofile := (*C.profile)(C.calloc(1, C.sizeof_profile))
+func goToCProfile(k *C.kuzzle, profile *security.Profile, dest *C.profile) *C.profile {
+	var cprofile *C.profile
+	if dest == nil {
+		cprofile = (*C.profile)(C.calloc(1, C.sizeof_profile))
+	} else {
+		cprofile = dest
+	}
 
 	cprofile.id = C.CString(profile.Id)
 	cprofile.policies_length = C.int(len(profile.Policies))
 	cprofile.kuzzle = k
 
 	if profile.Policies != nil {
-		cprofile.policies = (**C.policy)(C.calloc(C.size_t(len(profile.Policies)), C.sizeof_policy_ptr))
-		policies := (*[1<<30 - 1]*C.policy)(unsafe.Pointer(cprofile.policies))[:len(profile.Policies)]
+		cprofile.policies = (*C.policy)(C.calloc(C.size_t(len(profile.Policies)), C.sizeof_policy))
+		policies := (*[1<<30 - 1]C.policy)(unsafe.Pointer(cprofile.policies))[:len(profile.Policies)]
 		for i, policy := range profile.Policies {
-			policies[i] = goToCPolicy(policy)
+			goToCPolicy(policy, &policies[i])
 		}
 	}
 
@@ -315,18 +336,18 @@ func goToCProfileSearchResult(k *C.kuzzle, res *security.ProfileSearchResult, er
 	}
 
 	result.result = (*C.profile_search)(C.calloc(1, C.sizeof_profile_search))
-	result.result.length = C.int(len(res.Hits))
-	result.result.total = C.int(res.Total)
+	result.result.length = C.uint(len(res.Hits))
+	result.result.total = C.uint(res.Total)
 	if res.ScrollId != "" {
 		result.result.scrollId = C.CString(res.ScrollId)
 	}
 
 	if len(res.Hits) > 0 {
-		result.result.hits = (**C.profile)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_profile_ptr))
-		profiles := (*[1<<30 - 1]*C.profile)(unsafe.Pointer(result.result.hits))[:len(res.Hits)]
+		result.result.hits = (*C.profile)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_profile))
+		profiles := (*[1<<30 - 1]C.profile)(unsafe.Pointer(result.result.hits))[:len(res.Hits)]
 
 		for i, profile := range res.Hits {
-			profiles[i] = goToCProfile(k, profile)
+			goToCProfile(k, profile, &profiles[i])
 		}
 	}
 
@@ -342,15 +363,15 @@ func goToCRoleSearchResult(k *C.kuzzle, res *security.RoleSearchResult, err erro
 	}
 
 	result.result = (*C.role_search)(C.calloc(1, C.sizeof_role_search))
-	result.result.length = C.int(len(res.Hits))
-	result.result.total = C.int(res.Total)
+	result.result.length = C.uint(len(res.Hits))
+	result.result.total = C.uint(res.Total)
 
 	if len(res.Hits) > 0 {
-		result.result.hits = (**C.role)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_role_ptr))
-		cArray := (*[1<<30 - 1]*C.role)(unsafe.Pointer(result.result.hits))[:len(res.Hits):len(res.Hits)]
+		result.result.hits = (*C.role)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_role))
+		cArray := (*[1<<30 - 1]C.role)(unsafe.Pointer(result.result.hits))[:len(res.Hits):len(res.Hits)]
 
 		for i, role := range res.Hits {
-			cArray[i] = goToCRole(k, role)
+			goToCRole(k, role, &cArray[i])
 		}
 	}
 
@@ -388,11 +409,11 @@ func goToCSearchResult(col *C.collection, goRes *collection.SearchResult, err er
 	}
 
 	if len(goRes.Hits) > 0 {
-		result.result.hits = (**C.document)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_document_ptr))
-		cArray := (*[1<<30 - 1]*C.document)(unsafe.Pointer(result.result.hits))[:len(goRes.Hits):len(goRes.Hits)]
+		result.result.hits = (*C.document)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_document))
+		cArray := (*[1<<30 - 1]C.document)(unsafe.Pointer(result.result.hits))[:len(goRes.Hits):len(goRes.Hits)]
 
 		for i, doc := range goRes.Hits {
-			cArray[i] = goToCDocument(col, doc)
+			goToCDocument(col, doc, &cArray[i])
 		}
 	}
 
@@ -426,8 +447,13 @@ func goToCMappingResult(c *C.collection, goRes *collection.Mapping, err error) *
 	return result
 }
 
-func goToCRole(k *C.kuzzle, role *security.Role) *C.role {
-	crole := (*C.role)(C.calloc(1, C.sizeof_role))
+func goToCRole(k *C.kuzzle, role *security.Role, dest *C.role) *C.role {
+	var crole *C.role
+	if dest == nil {
+		crole = (*C.role)(C.calloc(1, C.sizeof_role))
+	} else {
+		crole = dest
+	}
 
 	crole.id = C.CString(role.Id)
 	crole.kuzzle = k
@@ -463,8 +489,14 @@ func goToCSpecification(goSpec *types.Specification) *C.specification {
 }
 
 // Allocates memory
-func goToCSpecificationEntry(goEntry *types.SpecificationEntry) *C.specification_entry {
-	result := (*C.specification_entry)(C.calloc(1, C.sizeof_specification_entry))
+func goToCSpecificationEntry(goEntry *types.SpecificationEntry, dest *C.specification_entry) *C.specification_entry {
+	var result *C.specification_entry
+	if dest == nil {
+		result = (*C.specification_entry)(C.calloc(1, C.sizeof_specification_entry))
+	} else {
+		result = dest
+	}
+
 	result.index = C.CString(goEntry.Index)
 	result.collection = C.CString(goEntry.Collection)
 	result.validation = goToCSpecification(goEntry.Validation)
@@ -501,11 +533,11 @@ func goToCSpecificationSearchResult(goRes *types.SpecificationSearchResult, err 
 	result.result.scrollId = C.CString(goRes.ScrollId)
 
 	if len(goRes.Hits) > 0 {
-		result.result.hits = (**C.specification_entry)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_specification_entry_ptr))
-		cArray := (*[1<<30 - 1]*C.specification_entry)(unsafe.Pointer(result.result.hits))[:len(goRes.Hits):len(goRes.Hits)]
+		result.result.hits = (*C.specification_entry)(C.calloc(C.size_t(len(goRes.Hits)), C.sizeof_specification_entry))
+		cArray := (*[1<<30 - 1]C.specification_entry)(unsafe.Pointer(result.result.hits))[:len(goRes.Hits):len(goRes.Hits)]
 
 		for i, spec := range goRes.Hits {
-			cArray[i] = goToCSpecificationEntry(&spec.Source)
+			goToCSpecificationEntry(&spec.Source, &cArray[i])
 		}
 	}
 
@@ -580,7 +612,7 @@ func goToCProfileResult(k *C.kuzzle, res *security.Profile, err error) *C.profil
 		return result
 	}
 
-	result.profile = goToCProfile(k, res)
+	result.profile = goToCProfile(k, res, nil)
 	return result
 }
 
@@ -612,12 +644,18 @@ func goToCUserData(data *types.UserData) (*C.user_data, error) {
 	return cdata, nil
 }
 
-func goToCUser(k *C.kuzzle, user *security.User) (*C.user, error) {
+func goToCUser(k *C.kuzzle, user *security.User, dest *C.user) (*C.user, error) {
 	if user == nil {
 		return nil, nil
 	}
 
-	cuser := (*C.user)(C.calloc(1, C.sizeof_user))
+	var cuser *C.user
+	if dest == nil {
+		cuser = (*C.user)(C.calloc(1, C.sizeof_user))
+	} else {
+		cuser = dest
+	}
+
 	cuser.id = C.CString(user.Id)
 	cuser.kuzzle = k
 
@@ -649,7 +687,7 @@ func goToCUserResult(k *C.kuzzle, user *security.User, err error) *C.user_result
 		return result
 	}
 
-	cuser, err := goToCUser(k, user)
+	cuser, err := goToCUser(k, user, nil)
 	if err != nil {
 		Set_user_result_error(result, err)
 		return result
@@ -670,23 +708,29 @@ func goToCProfilesResult(k *C.kuzzle, profiles []*security.Profile, err error) *
 	result.profiles_length = C.uint(len(profiles))
 
 	if profiles != nil {
-		result.profiles = (**C.profile)(C.calloc(C.size_t(len(profiles)), C.sizeof_profile_ptr))
-		carray := (*[1<<30 - 1]*C.profile)(unsafe.Pointer(result.profiles))[:len(profiles):len(profiles)]
+		result.profiles = (*C.profile)(C.calloc(C.size_t(len(profiles)), C.sizeof_profile))
+		carray := (*[1<<30 - 1]C.profile)(unsafe.Pointer(result.profiles))[:len(profiles):len(profiles)]
 
 		for i, profile := range profiles {
-			carray[i] = goToCProfile(k, profile)
+			goToCProfile(k, profile, &carray[i])
 		}
 	}
 
 	return result
 }
 
-func goToCUserRight(right *types.UserRights) *C.user_right {
+func goToCUserRight(right *types.UserRights, dest *C.user_right) *C.user_right {
 	if right == nil {
 		return nil
 	}
 
-	cright := (*C.user_right)(C.calloc(1, C.sizeof_user_right))
+	var cright *C.user_right
+	if dest == nil {
+		cright = (*C.user_right)(C.calloc(1, C.sizeof_user_right))
+	} else {
+		cright = dest
+	}
+
 	cright.controller = C.CString(right.Controller)
 	cright.action = C.CString(right.Action)
 	cright.index = C.CString(right.Index)
@@ -705,11 +749,38 @@ func goToCUserRightsResult(rights []*types.UserRights, err error) *C.user_rights
 
 	result.user_rights_length = C.uint(len(rights))
 	if rights != nil {
-		result.user_rights = (**C.user_right)(C.calloc(C.size_t(len(rights)), C.sizeof_user_right_ptr))
-		carray := (*[1<<30 - 1]*C.user_right)(unsafe.Pointer(result.user_rights))[:len(rights):len(rights)]
+		result.user_rights = (*C.user_right)(C.calloc(C.size_t(len(rights)), C.sizeof_user_right))
+		carray := (*[1<<30 - 1]C.user_right)(unsafe.Pointer(result.user_rights))[:len(rights):len(rights)]
 
 		for i, right := range rights {
-			carray[i] = goToCUserRight(right)
+			goToCUserRight(right, &carray[i])
+		}
+	}
+
+	return result
+}
+
+func goToCUserSearchResult(k *C.kuzzle, res *security.UserSearchResult, err error) *C.search_users_result {
+	result := (*C.search_users_result)(C.calloc(1, C.sizeof_search_users_result))
+
+	if err != nil {
+		Set_search_users_result_error(result, err)
+		return result
+	}
+
+	result.result = (*C.user_search)(C.calloc(1, C.sizeof_user_search))
+	result.result.length = C.uint(len(res.Hits))
+	result.result.total = C.uint(res.Total)
+	if res.ScrollId != "" {
+		result.result.scrollId = C.CString(res.ScrollId)
+	}
+
+	if len(res.Hits) > 0 {
+		result.result.hits = (*C.user)(C.calloc(C.size_t(len(res.Hits)), C.sizeof_user))
+		users := (*[1<<30 - 1]C.user)(unsafe.Pointer(result.result.hits))[:len(res.Hits)]
+
+		for i, user := range res.Hits {
+			goToCUser(k, user, &users[i])
 		}
 	}
 

--- a/cgo/kuzzle/security.go
+++ b/cgo/kuzzle/security.go
@@ -16,11 +16,14 @@ import (
 	"unsafe"
 )
 
+// --- profile
+
 //export kuzzle_wrapper_security_new_profile
-func kuzzle_wrapper_security_new_profile(k *C.kuzzle, id *C.char, policies **C.policy) *C.profile {
+func kuzzle_wrapper_security_new_profile(k *C.kuzzle, id *C.char, policies *C.policy, policies_length C.int) *C.profile {
 	cprofile := (*C.profile)(C.calloc(1, C.sizeof_profile))
 	cprofile.id = id
 	cprofile.policies = policies
+	cprofile.policies_length = policies_length
 	cprofile.kuzzle = k
 
 	return cprofile
@@ -67,7 +70,7 @@ func kuzzle_wrapper_security_fetch_profile(k *C.kuzzle, id *C.char, o *C.query_o
 		return result
 	}
 
-	result.profile = goToCProfile(k, profile)
+	result.profile = goToCProfile(k, profile, nil)
 
 	return result
 }
@@ -92,7 +95,8 @@ func kuzzle_wrapper_security_search_profiles(k *C.kuzzle, f *C.search_filters, o
 func kuzzle_wrapper_security_profile_add_policy(p *C.profile, policy *C.policy) *C.profile {
 	profile := cToGoProfile(p).AddPolicy(cToGoPolicy(policy))
 
-	return goToCProfile(p.kuzzle, profile)
+	// @TODO: check if this method is useful and if so, the original pointer to p should be returned instead of a new allocated struct
+	return goToCProfile(p.kuzzle, profile, nil)
 }
 
 //export kuzzle_wrapper_security_profile_delete
@@ -112,6 +116,8 @@ func kuzzle_wrapper_security_profile_save(p *C.profile, o *C.query_options) *C.p
 
 	return goToCProfileResult(p.kuzzle, res, err)
 }
+
+// --- role
 
 //export kuzzle_wrapper_security_new_role
 func kuzzle_wrapper_security_new_role(k *C.kuzzle, id *C.char, c *C.controllers) *C.role {
@@ -150,7 +156,7 @@ func kuzzle_wrapper_security_fetch_role(k *C.kuzzle, id *C.char, o *C.query_opti
 		return result
 	}
 
-	result.role = goToCRole(k, role)
+	result.role = goToCRole(k, role, nil)
 
 	return result
 }
@@ -194,10 +200,12 @@ func kuzzle_wrapper_security_role_save(r *C.role, o *C.query_options) *C.role_re
 		return result
 	}
 
-	result.role = goToCRole(r.kuzzle, res)
+	result.role = goToCRole(r.kuzzle, res, nil)
 
 	return result
 }
+
+// --- user
 
 //export kuzzle_wrapper_security_new_user
 func kuzzle_wrapper_security_new_user(k *C.kuzzle, id *C.char, d *C.user_data) *C.user {
@@ -238,6 +246,24 @@ func kuzzle_wrapper_security_destroy_user(u *C.user) {
 	}
 
 	C.free(unsafe.Pointer(u))
+}
+
+//export kuzzle_wrapper_security_fetch_user
+func kuzzle_wrapper_security_fetch_user(k *C.kuzzle, id *C.char, o *C.query_options) *C.user_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.FetchUser(C.GoString(id), SetQueryOptions(o))
+	return goToCUserResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_scroll_users
+func kuzzle_wrapper_security_scroll_users(k *C.kuzzle, s *C.char, o *C.query_options) *C.search_users_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.ScrollUsers(C.GoString(s), SetQueryOptions(o))
+	return goToCUserSearchResult(k, res, err)
+}
+
+//export kuzzle_wrapper_security_search_users
+func kuzzle_wrapper_security_search_users(k *C.kuzzle, f *C.search_filters, o *C.query_options) *C.search_users_result {
+	res, err := (*kuzzle.Kuzzle)(k.instance).Security.SearchUsers(cToGoSearchFilters(f), SetQueryOptions(o))
+	return goToCUserSearchResult(k, res, err)
 }
 
 //export kuzzle_wrapper_security_user_create

--- a/headers/kuzzlesdk.h
+++ b/headers/kuzzlesdk.h
@@ -150,13 +150,13 @@ typedef struct {
 
 typedef struct {
     char *role_id;
-    policy_restriction **restricted_to;
+    policy_restriction *restricted_to;
     int restricted_to_length;
 } policy;
 
 typedef struct {
     char *id;
-    policy **policies;
+    policy *policies;
     int policies_length;
     kuzzle *kuzzle;
 } profile;
@@ -252,7 +252,7 @@ typedef struct {
 } profile_result;
 
 typedef struct {
-    profile **profiles;
+    profile *profiles;
     uint profiles_length;
     int status;
     char *error;
@@ -275,7 +275,7 @@ typedef struct {
 } user_right;
 
 typedef struct {
-    user_right **user_rights;
+    user_right *user_rights;
     uint user_rights_length;
     int status;
     char *error;
@@ -436,24 +436,31 @@ typedef struct {
 } search_filters;
 
 typedef struct {
-    document** hits;
+    document *hits;
     uint length;
     uint total;
     char *scrollId;
 } document_search;
 
 typedef struct {
-    profile **hits;
-    int length;
-    int total;
+    profile *hits;
+    uint length;
+    uint total;
     char *scrollId;
 } profile_search;
 
 typedef struct {
-    role** hits;
-    int length;
-    int total;
+    role *hits;
+    uint length;
+    uint total;
 } role_search;
+
+typedef struct {
+    user *hits;
+    uint length;
+    uint total;
+    char *scrollId;
+} user_search;
 
 //any delete* function
 typedef struct {
@@ -512,7 +519,14 @@ typedef struct {
 } search_roles_result;
 
 typedef struct {
-    specification_entry** hits;
+    user_search *result;
+    int status;
+    char *error;
+    char *stack;
+} search_users_result;
+
+typedef struct {
+    specification_entry *hits;
     uint length;
     uint total;
     char *scrollId;

--- a/headers/sdk_wrappers_internal.h
+++ b/headers/sdk_wrappers_internal.h
@@ -5,11 +5,6 @@ typedef char *char_ptr;
 typedef document *document_ptr;
 typedef policy *policy_ptr;
 typedef policy_restriction *policy_restriction_ptr;
-typedef profile *profile_ptr;
-typedef role *role_ptr;
-typedef user *user_ptr;
-typedef user_right *user_right_ptr;
-typedef specification_entry *specification_entry_ptr;
 typedef json_object *json_object_ptr;
 typedef query_object *query_object_ptr;
 

--- a/io/kuzzle/sdk/.gitignore
+++ b/io/kuzzle/sdk/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore


### PR DESCRIPTION
Implement returned struct list as simple pointers
NB: json_array_result is left as is as json_tokener_parse allocates a json_object by itself.

## Boyscouting

* implement missing `search_users` and `scroll_users`
* .gitignore